### PR TITLE
Switch login to email

### DIFF
--- a/lib/features/auth/providers/auth_provider.dart
+++ b/lib/features/auth/providers/auth_provider.dart
@@ -81,6 +81,30 @@ class AuthNotifier extends StateNotifier<AuthState> {
     }
   }
 
+  Future<void> signInWithEmail(String email, String password) async {
+    state = state.copyWith(status: AuthStatus.verifyingCode);
+    final authService = _ref.read(authServiceProvider);
+    final result = await authService.signInWithEmail(
+      email: email,
+      password: password,
+    );
+    if (!result.isSuccess) {
+      state = state.copyWith(status: AuthStatus.error, message: result.message);
+    }
+  }
+
+  Future<void> signUpWithEmail(String email, String password) async {
+    state = state.copyWith(status: AuthStatus.sendingCode);
+    final authService = _ref.read(authServiceProvider);
+    final result = await authService.signUpWithEmail(
+      email: email,
+      password: password,
+    );
+    if (!result.isSuccess) {
+      state = state.copyWith(status: AuthStatus.error, message: result.message);
+    }
+  }
+
   Future<void> createProfile(String name) async {
     state = state.copyWith(status: AuthStatus.creatingProfile);
 

--- a/lib/features/auth/screens/create_profile_screen.dart
+++ b/lib/features/auth/screens/create_profile_screen.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:junta/shared/models/auth_state.dart';
+import 'package:junta/features/auth/providers/auth_provider.dart';
 
 class CreateProfileScreen extends ConsumerStatefulWidget {
   const CreateProfileScreen({super.key});
@@ -20,10 +21,10 @@ class _CreateProfileScreenState extends ConsumerState<CreateProfileScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final authState = ref.watch(authControllerProvider);
+    final authState = ref.watch(authStateProvider);
 
     // Escuchar cambios de estado
-    ref.listen<AuthState>(authControllerProvider, (previous, next) {
+    ref.listen<AuthState>(authStateProvider, (previous, next) {
       if (next.status == AuthStatus.authenticated) {
         Navigator.pushReplacementNamed(context, '/dashboard');
       } else if (next.status == AuthStatus.error) {
@@ -180,7 +181,7 @@ class _CreateProfileScreenState extends ConsumerState<CreateProfileScreen> {
     if (!_formKey.currentState!.validate()) return;
 
     ref
-        .read(authControllerProvider.notifier)
+        .read(authStateProvider.notifier)
         .createUserProfile(_nameController.text);
   }
 

--- a/lib/features/auth/screens/email_auth_screen.dart
+++ b/lib/features/auth/screens/email_auth_screen.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:junta/shared/models/auth_state.dart';
+import 'package:junta/features/auth/providers/auth_provider.dart';
+
+class EmailAuthScreen extends ConsumerStatefulWidget {
+  const EmailAuthScreen({super.key});
+
+  @override
+  ConsumerState<EmailAuthScreen> createState() => _EmailAuthScreenState();
+}
+
+class _EmailAuthScreenState extends ConsumerState<EmailAuthScreen> {
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  final _formKey = GlobalKey<FormState>();
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      ref.listen<AuthState>(authStateProvider, (previous, next) {
+        if (!mounted) return;
+        switch (next.status) {
+          case AuthStatus.creatingProfile:
+            context.go('/create-profile');
+            break;
+          case AuthStatus.authenticated:
+            context.go('/dashboard');
+            break;
+          case AuthStatus.error:
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text(next.message ?? 'Error'), backgroundColor: Colors.red),
+            );
+            break;
+          default:
+            break;
+        }
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final authState = ref.watch(authStateProvider);
+    return Scaffold(
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                const Spacer(),
+                TextFormField(
+                  controller: _emailController,
+                  decoration: const InputDecoration(labelText: 'Email'),
+                  keyboardType: TextInputType.emailAddress,
+                  validator: (v) => v == null || v.isEmpty ? 'Ingresa tu email' : null,
+                ),
+                const SizedBox(height: 16),
+                TextFormField(
+                  controller: _passwordController,
+                  decoration: const InputDecoration(labelText: 'Contraseña'),
+                  obscureText: true,
+                  validator: (v) => v == null || v.length < 6 ? 'Mínimo 6 caracteres' : null,
+                ),
+                const SizedBox(height: 24),
+                ElevatedButton(
+                  onPressed: authState.status == AuthStatus.verifyingCode ? null : _login,
+                  child: const Text('Iniciar sesión'),
+                ),
+                const SizedBox(height: 12),
+                TextButton(
+                  onPressed: authState.status == AuthStatus.sendingCode ? null : _register,
+                  child: const Text('Registrarme'),
+                ),
+                const Spacer(flex: 2),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _login() {
+    if (!_formKey.currentState!.validate()) return;
+    ref.read(authStateProvider.notifier).signInWithEmail(
+          _emailController.text.trim(),
+          _passwordController.text.trim(),
+        );
+  }
+
+  void _register() {
+    if (!_formKey.currentState!.validate()) return;
+    ref.read(authStateProvider.notifier).signUpWithEmail(
+          _emailController.text.trim(),
+          _passwordController.text.trim(),
+        );
+  }
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+}

--- a/lib/features/auth/screens/splash_screen.dart
+++ b/lib/features/auth/screens/splash_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import '../controllers/auth_controller.dart';
+import 'package:junta/features/auth/providers/auth_provider.dart';
 import 'package:junta/shared/models/auth_state.dart';
 
 class SplashScreen extends ConsumerStatefulWidget {
@@ -50,7 +50,7 @@ class _SplashScreenState extends ConsumerState<SplashScreen>
   void _checkAuthState() {
     if (!mounted || _hasNavigated) return;
 
-    final authState = ref.read(authControllerProvider);
+    final authState = ref.read(authStateProvider);
     _navigateBasedOnAuthState(authState);
   }
 
@@ -70,7 +70,7 @@ class _SplashScreenState extends ConsumerState<SplashScreen>
       case AuthStatus.error:
       case AuthStatus.initial:
       default:
-        context.go('/phone-auth');
+        context.go('/auth');
         break;
     }
   }
@@ -78,7 +78,7 @@ class _SplashScreenState extends ConsumerState<SplashScreen>
   @override
   Widget build(BuildContext context) {
     // Escuchar cambios de estado de autenticación
-    ref.listen<AuthState>(authControllerProvider, (previous, next) {
+    ref.listen<AuthState>(authStateProvider, (previous, next) {
       // Solo navegar si la animación terminó y no hemos navegado aún
       if (_animationController.isCompleted && !_hasNavigated) {
         // Dar un pequeño delay para que la UI se estabilice
@@ -163,7 +163,7 @@ class _SplashScreenState extends ConsumerState<SplashScreen>
                     // Estado de carga
                     Consumer(
                       builder: (context, ref, child) {
-                        final authState = ref.watch(authControllerProvider);
+                        final authState = ref.watch(authStateProvider);
                         String loadingText = 'Inicializando...';
 
                         switch (authState.status) {

--- a/lib/features/auth/services/auth_service.dart
+++ b/lib/features/auth/services/auth_service.dart
@@ -94,6 +94,38 @@ class AuthService {
     return await _auth.signInWithCredential(credential);
   }
 
+  // INICIAR SESIÓN CON EMAIL Y CONTRASEÑA
+  Future<AuthResult> signInWithEmail({
+    required String email,
+    required String password,
+  }) async {
+    try {
+      await _auth.signInWithEmailAndPassword(
+        email: email,
+        password: password,
+      );
+      return AuthResult.success('Sesión iniciada');
+    } catch (e) {
+      return AuthResult.error(_getErrorMessage(e));
+    }
+  }
+
+  // REGISTRAR USUARIO CON EMAIL Y CONTRASEÑA
+  Future<AuthResult> signUpWithEmail({
+    required String email,
+    required String password,
+  }) async {
+    try {
+      await _auth.createUserWithEmailAndPassword(
+        email: email,
+        password: password,
+      );
+      return AuthResult.success('Cuenta creada');
+    } catch (e) {
+      return AuthResult.error(_getErrorMessage(e));
+    }
+  }
+
   // 4. CREAR/ACTUALIZAR PERFIL DE USUARIO
   Future<AuthResult> createUserProfile({
     required String name,
@@ -111,7 +143,8 @@ class AuthService {
       final appUser = AppUser(
         id: user.uid,
         name: name,
-        phone: user.phoneNumber ?? '',
+        email: user.email ?? '',
+        phone: user.phoneNumber,
         photoUrl: photoUrl,
         createdAt: userDoc.exists
             ? DateTime.fromMillisecondsSinceEpoch(userDoc.data()!['createdAt'])
@@ -199,6 +232,14 @@ class AuthService {
       switch (error.code) {
         case 'invalid-phone-number':
           return 'Número de teléfono inválido';
+        case 'invalid-email':
+          return 'Email inválido';
+        case 'user-not-found':
+          return 'Usuario no encontrado';
+        case 'wrong-password':
+          return 'Contraseña incorrecta';
+        case 'email-already-in-use':
+          return 'El email ya está en uso';
         case 'too-many-requests':
           return 'Demasiados intentos. Intenta más tarde';
         case 'invalid-verification-code':

--- a/lib/features/contacts/providers/contact_providers.dart
+++ b/lib/features/contacts/providers/contact_providers.dart
@@ -25,10 +25,9 @@ final filteredContactsProvider = Provider<List<AppUser>>((ref) {
 
       if (searchQuery.isNotEmpty) {
         filtered = filtered.where((contact) {
-          return contact.displayName.toLowerCase().contains(
-                searchQuery.toLowerCase(),
-              ) ||
-              contact.phone.contains(searchQuery);
+          final query = searchQuery.toLowerCase();
+          return contact.displayName.toLowerCase().contains(query) ||
+              contact.email.toLowerCase().contains(query);
         }).toList();
       }
 

--- a/lib/features/contacts/screens/contact_selection_screen.dart
+++ b/lib/features/contacts/screens/contact_selection_screen.dart
@@ -212,7 +212,7 @@ class _ContactSelectionScreenOptimizedState
             fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
           ),
         ),
-        subtitle: Text(contact.phone),
+        subtitle: Text(contact.email),
         trailing: isSelected
             ? Icon(Icons.check_circle, color: Theme.of(context).primaryColor)
             : Icon(Icons.add_circle_outline),

--- a/lib/features/groups/screens/create_group_screen.dart
+++ b/lib/features/groups/screens/create_group_screen.dart
@@ -247,7 +247,7 @@ class _CreateGroupScreenState extends ConsumerState<CreateGroupScreen> {
             : null,
       ),
       title: Text(user.displayName),
-      subtitle: Text(user.phone),
+      subtitle: Text(user.email),
       trailing: IconButton(
         icon: Icon(Icons.remove_circle_outline, color: Colors.red),
         onPressed: () => controller.removeContact(user),

--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -5,8 +5,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:flutter/material.dart';
 import 'package:junta/features/auth/providers/auth_provider.dart';
-import 'package:junta/features/auth/screens/phone_auth_screen.dart';
+import 'package:junta/features/auth/screens/email_auth_screen.dart';
 import 'package:junta/features/auth/screens/splash_screen.dart';
+import 'package:junta/features/auth/screens/create_profile_screen.dart';
 import 'package:junta/features/groups/screens/create_group_screen.dart';
 import 'package:junta/features/groups/screens/dashboard_screen.dart';
 import '../shared/models/auth_state.dart';
@@ -18,7 +19,7 @@ final routerProvider = Provider<GoRouter>((ref) {
     refreshListenable: RouterRefreshNotifier(ref),
     routes: [
       GoRoute(path: '/', builder: (context, state) => SplashScreen()),
-      GoRoute(path: '/auth', builder: (context, state) => PhoneAuthScreen()),
+      GoRoute(path: '/auth', builder: (context, state) => const EmailAuthScreen()),
       GoRoute(
         path: '/create-profile',
         builder: (context, state) => CreateProfileScreen(),

--- a/lib/shared/models/user_model.dart
+++ b/lib/shared/models/user_model.dart
@@ -2,7 +2,8 @@
 class AppUser {
   final String id;
   final String name;
-  final String phone;
+  final String email;
+  final String? phone;
   final String? photoUrl;
   final DateTime createdAt;
   final bool isOnline;
@@ -11,7 +12,8 @@ class AppUser {
   AppUser({
     required this.id,
     required this.name,
-    required this.phone,
+    required this.email,
+    this.phone,
     this.photoUrl,
     required this.createdAt,
     this.isOnline = false,
@@ -25,6 +27,7 @@ class AppUser {
     return {
       'id': id,
       'name': name,
+      'email': email,
       'phone': phone,
       'photoUrl': photoUrl,
       'createdAt': createdAt.millisecondsSinceEpoch,
@@ -36,6 +39,7 @@ class AppUser {
     return AppUser(
       id: map['id'],
       name: map['name'],
+      email: map['email'],
       phone: map['phone'],
       photoUrl: map['photoUrl'],
       createdAt: DateTime.fromMillisecondsSinceEpoch(map['createdAt']),
@@ -46,6 +50,7 @@ class AppUser {
   AppUser copyWith({
     String? id,
     String? name,
+    String? email,
     String? phone,
     String? photoUrl,
     DateTime? createdAt,
@@ -55,6 +60,7 @@ class AppUser {
     return AppUser(
       id: id ?? this.id,
       name: name ?? this.name,
+      email: email ?? this.email,
       phone: phone ?? this.phone,
       photoUrl: photoUrl ?? this.photoUrl,
       createdAt: createdAt ?? this.createdAt,


### PR DESCRIPTION
## Summary
- add EmailAuthScreen
- update router and splash screen for email login
- store user emails in `AppUser`
- search contacts by email instead of phone
- display emails in contact lists and group screens
- implement email login/signup in auth services and provider

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866e620151483309c3a4afd0055d602