### PR TITLE
Fix profile creation method references

### DIFF
--- a/lib/features/auth/screens/create_profile_screen.dart
+++ b/lib/features/auth/screens/create_profile_screen.dart
@@ -182,7 +182,7 @@ class _CreateProfileScreenState extends ConsumerState<CreateProfileScreen> {
 
     ref
         .read(authStateProvider.notifier)
-        .createUserProfile(_nameController.text);
+        .createProfile(_nameController.text);
   }
 
   @override

--- a/lib/features/auth/screens/phone_auth_screen.dart
+++ b/lib/features/auth/screens/phone_auth_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:junta/core/providers/app_provider.dart';
 import '../../../shared/models/auth_state.dart';
+import 'package:junta/features/auth/providers/auth_provider.dart';
 
 class PhoneAuthScreen extends ConsumerStatefulWidget {
   @override
@@ -603,7 +604,7 @@ class _CreateProfileScreenState extends ConsumerState<CreateProfileScreen> {
 
     ref
         .read(authStateProvider.notifier)
-        .createUserProfile(_nameController.text);
+        .createProfile(_nameController.text);
   }
 
   @override


### PR DESCRIPTION
## Summary
- import `auth_provider` in phone auth screen
- call `createProfile` instead of undefined `createUserProfile`

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866e9ceb38083309c00e6ee403033d5