### PR TITLE
Fix missing providers

### DIFF
--- a/lib/features/contacts/providers/contact_providers.dart
+++ b/lib/features/contacts/providers/contact_providers.dart
@@ -4,6 +4,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../shared/models/user_model.dart';
 import '../../../core/providers/service_providers.dart';
+import '../../groups/providers/group_providers.dart';
 
 final registeredContactsProvider = FutureProvider<List<AppUser>>((ref) async {
   final contactService = ref.read(contactServiceProvider);

--- a/lib/features/contacts/screens/contact_selection_screen.dart
+++ b/lib/features/contacts/screens/contact_selection_screen.dart
@@ -60,7 +60,7 @@ class _ContactSelectionScreenOptimizedState
                         icon: Icon(Icons.clear),
                         onPressed: () {
                           _searchController.clear();
-                          groupController.updateSearch('');
+                          ref.read(contactSearchProvider.notifier).state = '';
                         },
                       )
                     : null,
@@ -69,7 +69,7 @@ class _ContactSelectionScreenOptimizedState
                 ),
               ),
               onChanged: (value) {
-                groupController.updateSearch(value);
+                ref.read(contactSearchProvider.notifier).state = value;
               },
             ),
           ),

--- a/lib/features/groups/providers/group_providers.dart
+++ b/lib/features/groups/providers/group_providers.dart
@@ -18,7 +18,9 @@ final userGroupsProvider = StreamProvider<List<JuntaGroup>>((ref) {
 
 final selectedContactsProvider = StateProvider<List<AppUser>>((ref) => []);
 
-final groupCreationProvider = Provider<GroupCreationController>((ref) {
+final isCreatingGroupProvider = StateProvider<bool>((ref) => false);
+
+final groupCreationControllerProvider = Provider<GroupCreationController>((ref) {
   return GroupCreationController(ref);
 });
 

--- a/lib/features/groups/screens/create_group_screen.dart
+++ b/lib/features/groups/screens/create_group_screen.dart
@@ -287,6 +287,8 @@ class _CreateGroupScreenState extends ConsumerState<CreateGroupScreen> {
       return;
     }
 
+    final isCreatingNotifier = ref.read(isCreatingGroupProvider.notifier);
+    isCreatingNotifier.state = true;
     try {
       final groupController = ref.read(groupCreationControllerProvider);
 
@@ -310,6 +312,8 @@ class _CreateGroupScreenState extends ConsumerState<CreateGroupScreen> {
           SnackBar(content: Text('Error: $e'), backgroundColor: Colors.red),
         );
       }
+    } finally {
+      isCreatingNotifier.state = false;
     }
   }
 


### PR DESCRIPTION
## Summary
- import group provider into contact providers
- update contact search to set state directly
- rename and export group creation controller provider
- add boolean provider for group creation progress
- toggle creation state in UI when creating group

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866eab7b458833081745ccbaeae395a